### PR TITLE
Tests e2e de Login y AddUser

### DIFF
--- a/webapp/e2e/features/login-form.feature
+++ b/webapp/e2e/features/login-form.feature
@@ -1,0 +1,16 @@
+Feature: Login functionality
+
+Scenario: The user logs in successfully
+Given A registered user with valid credentials
+When I fill the login form and submit it
+Then I should be redirected to the homepage
+
+Scenario: The user logs in with invalid credentials
+Given A user with invalid credentials
+When I fill the login form and submit it
+Then An error message should appear indicating invalid credentials
+
+Scenario: The user attempts to log in more than 5 times with incorrect credentials and is told to try again later
+Given A user who attempts to log in more than 5 times with incorrect credentials
+When I attempt to log in with invalid credentials more than 5 times
+Then A security message should appear saying to try again later

--- a/webapp/e2e/features/register-form.feature
+++ b/webapp/e2e/features/register-form.feature
@@ -2,5 +2,15 @@ Feature: Registering a new user
 
 Scenario: The user is not registered in the site
   Given An unregistered user
-  When I fill the data in the form and press submit
-  Then A confirmation message should be shown in the screen
+  When I fill the registration form and submit it
+  Then A success message should appear
+
+Scenario: The user is not registered but the password is invalid
+  Given An unregistered user with an invalid password
+  When I fill the registration form and submit it
+  Then An error message about password content should appear
+
+Scenario: The user is not registered, the password is valid but they don't match
+  Given An unregistered user with valid but mismatching passwords
+  When I fill the registration form and submit it
+  Then An error message about password mismatch should appear

--- a/webapp/e2e/features/register-form.feature
+++ b/webapp/e2e/features/register-form.feature
@@ -14,3 +14,8 @@ Scenario: The user is not registered, the password is valid but they don't match
   Given An unregistered user with valid but mismatching passwords
   When I fill the registration form and submit it
   Then An error message about password mismatch should appear
+
+Scenario: The user tries to register with an existing username
+  Given A user that is already registered
+  When I fill the registration form with the same username and submit it
+  Then An error message about existing username should appear

--- a/webapp/e2e/i18n-test-helper.js
+++ b/webapp/e2e/i18n-test-helper.js
@@ -1,0 +1,19 @@
+// e2e/steps/i18n-test-helper.js
+const i18n = require('i18next');
+const translationEN = require('../public/locales/en/translation.json');
+const translationES = require('../public/locales/es/translation.json');
+
+i18n.init({
+  lng: 'es',  // It is 'es' because the test takes the default language of the browser.
+  fallbackLng: 'es',
+  debug: false,
+  interpolation: {
+    escapeValue: false,
+  },
+  resources: {
+    en: { translation: translationEN },
+    es: { translation: translationES },
+  },
+});
+
+module.exports = i18n;

--- a/webapp/e2e/steps/login-form.steps.js
+++ b/webapp/e2e/steps/login-form.steps.js
@@ -1,0 +1,112 @@
+// src/e2e/steps/login-form.steps.js
+const puppeteer = require('puppeteer');
+const { defineFeature, loadFeature } = require('jest-cucumber');
+const setDefaultOptions = require('expect-puppeteer').setDefaultOptions;
+const feature = loadFeature('./features/login-form.feature');
+const i18n = require('../i18n-test-helper.js'); 
+const axios = require('axios');
+
+
+let page;
+let browser;
+
+defineFeature(feature, test => {
+  beforeAll(async () => {
+    browser = process.env.GITHUB_ACTIONS
+      ? await puppeteer.launch({ headless: "new", args: ['--no-sandbox', '--disable-setuid-sandbox'] })
+      : await puppeteer.launch({ headless: false, slowMo: 10 });
+
+    page = await browser.newPage();
+    setDefaultOptions({ timeout: 30000 });
+  });
+
+  beforeEach(async () => {
+    await page.goto("http://localhost:3000/login", {
+      waitUntil: "networkidle0",
+    });
+  });
+
+  let username, password;
+
+  test('The user logs in successfully', ({ given, when, then }) => {
+    given('A registered user with valid credentials', async () => {
+      username = "validUser";
+      password = "ValidPassword123";
+
+       // Register the user if not already registered
+       await axios.post('http://localhost:8000/adduser', {
+        username: username,
+        password: password,
+        confirmPassword: password,
+      });
+    });
+
+    when('I fill the login form and submit it', async () => {
+      await expect(page).toFill(`input[placeholder="${i18n.t('enter-username-placeholder')}"]`, username);
+      await expect(page).toFill(`input[placeholder="${i18n.t('enter-password-placeholder')}"]`, password);
+      await expect(page).toClick('button', { text: i18n.t('login-message') });
+    });
+
+    then('I should be redirected to the homepage', async () => {
+        await expect(page).toMatchElement('h1', { text: i18n.t('welcome-home') });
+        
+
+         // Hacer clic en las tres rayitas para desplegar el menú
+      await page.click('.navbar-toggler');  // Esto abre el menú hamburguesa en dispositivos móviles
+
+      // Esperamos que el botón de logout sea visible ahora
+      await page.waitForSelector('nav [data-testid="logout-icon"]'); // Esperamos que el icono de logout sea visible
+
+      // Hacemos clic en el icono de logout
+      await page.click('nav [data-testid="logout-icon"]');
+
+      // Esperamos a que el modal de confirmación aparezca
+      await page.waitForSelector('.modal-footer button.btn-danger');  // Esperamos el botón de confirmación
+
+      // Hacemos clic en el botón de "Confirmar" del modal para cerrar sesión
+      await page.click('.modal-footer button.btn-danger');
+    });
+  });
+
+  test('The user logs in with invalid credentials', ({ given, when, then }) => {
+    given('A user with invalid credentials', async () => {
+      username = "invalidUser";
+      password = "WrongPassword123";
+    });
+
+    when('I fill the login form and submit it', async () => {
+      await expect(page).toFill(`input[placeholder="${i18n.t('enter-username-placeholder')}"]`, username);
+      await expect(page).toFill(`input[placeholder="${i18n.t('enter-password-placeholder')}"]`, password);
+      await expect(page).toClick('button', { text: i18n.t('login-message') });
+    });
+
+    then('An error message should appear indicating invalid credentials', async () => {
+      await expect(page).toMatchElement("div.alert-danger", { text: i18n.t('auth-error-bad-credentials') });
+    });
+  });
+
+  test('The user attempts to log in more than 5 times with incorrect credentials and is told to try again later', ({ given, when, then }) => {
+    given('A user who attempts to log in more than 5 times with incorrect credentials', async () => {
+      username = "lockedUser";
+      password = "WrongPassword123";
+    });
+
+    when('I attempt to log in with invalid credentials more than 5 times', async () => {
+      for (let i = 0; i < 4; i++) {
+        await expect(page).toFill(`input[placeholder="${i18n.t('enter-username-placeholder')}"]`, username);
+        await expect(page).toFill(`input[placeholder="${i18n.t('enter-password-placeholder')}"]`, password);
+        await expect(page).toClick('button', { text: i18n.t('login-message') });
+      }
+    });
+
+    then('A security message should appear saying to try again later', async () => {
+      await expect(page).toMatchElement("div.alert-danger", { text: i18n.t('auth-error-too-many-attempts') });
+    });
+  });
+
+  
+
+  afterAll(async () => {
+    await browser.close();
+  });
+});

--- a/webapp/e2e/steps/register-form.steps.js
+++ b/webapp/e2e/steps/register-form.steps.js
@@ -12,7 +12,7 @@ defineFeature(feature, test => {
   beforeAll(async () => {
     browser = process.env.GITHUB_ACTIONS
       ? await puppeteer.launch({ headless: "new", args: ['--no-sandbox', '--disable-setuid-sandbox'] })
-      : await puppeteer.launch({ headless: false, slowMo: 100 });
+      : await puppeteer.launch({ headless: false, slowMo: 10 });
 
     page = await browser.newPage();
     setDefaultOptions({ timeout: 10000 });

--- a/webapp/e2e/steps/register-form.steps.js
+++ b/webapp/e2e/steps/register-form.steps.js
@@ -86,6 +86,38 @@ defineFeature(feature, test => {
     });
   });
 
+  test("The user tries to register with an existing username", ({ given, when, then }) => {
+    given("A user that is already registered", async () => {
+      username = "alreadyExistsUser";
+      password = "ValidPass123";
+      confirmPassword = "ValidPass123";
+
+      // Intentamos registrar el usuario por primera vez
+      await expect(page).toFill(`input[placeholder="${i18n.t('enter-username-placeholder')}"]`, username);
+      await expect(page).toFill(`input[placeholder="${i18n.t('enter-password-placeholder')}"]`, password);
+      await expect(page).toFill(`input[placeholder="${i18n.t('enter-confirm-password-placeholder')}"]`, confirmPassword);
+      await expect(page).toClick('button', { text: i18n.t('signup-message') });
+
+      // Esperamos al mensaje de éxito
+      await expect(page).toMatchElement("div.alert-success", { text: i18n.t('user-added') });
+
+      // Recargamos para hacer el segundo intento
+      await page.reload({ waitUntil: "networkidle0" });
+    });
+
+    when("I fill the registration form with the same username and submit it", async () => {
+      await expect(page).toFill(`input[placeholder="${i18n.t('enter-username-placeholder')}"]`, username);
+      await expect(page).toFill(`input[placeholder="${i18n.t('enter-password-placeholder')}"]`, password);
+      await expect(page).toFill(`input[placeholder="${i18n.t('enter-confirm-password-placeholder')}"]`, confirmPassword);
+      await expect(page).toClick('button', { text: i18n.t('signup-message') });
+    });
+
+    then("An error message about existing username should appear", async () => {
+      await expect(page).toMatchElement("div.alert-danger", { text: i18n.t('user-not-added') + i18n.t('username-already-exists') });
+    });
+  });
+
+
   afterAll(async () => {
     await browser.close();
   });

--- a/webapp/e2e/steps/register-form.steps.js
+++ b/webapp/e2e/steps/register-form.steps.js
@@ -1,52 +1,92 @@
 const puppeteer = require('puppeteer');
-const { defineFeature, loadFeature }=require('jest-cucumber');
-const setDefaultOptions = require('expect-puppeteer').setDefaultOptions
+const { defineFeature, loadFeature } = require('jest-cucumber');
+const setDefaultOptions = require('expect-puppeteer').setDefaultOptions;
 const feature = loadFeature('./features/register-form.feature');
+const i18n = require('../i18n-test-helper.js');
+
 
 let page;
 let browser;
 
 defineFeature(feature, test => {
-  
   beforeAll(async () => {
     browser = process.env.GITHUB_ACTIONS
-      ? await puppeteer.launch({headless: "new", args: ['--no-sandbox', '--disable-setuid-sandbox']})
+      ? await puppeteer.launch({ headless: "new", args: ['--no-sandbox', '--disable-setuid-sandbox'] })
       : await puppeteer.launch({ headless: false, slowMo: 100 });
-    page = await browser.newPage();
-    //Way of setting up the timeout
-    setDefaultOptions({ timeout: 10000 })
 
-    await page
-      .goto("http://localhost:3000", {
-        waitUntil: "networkidle0",
-      })
-      .catch(() => {});
+    page = await browser.newPage();
+    setDefaultOptions({ timeout: 10000 });
   });
 
-  test('The user is not registered in the site', ({given,when,then}) => {
-    
-    let username;
-    let password;
+  beforeEach(async () => {
+    await page.goto("http://localhost:3000/adduser", {
+      waitUntil: "networkidle0",
+    });
+  });
 
+  let username, password, confirmPassword;
+
+  test('The user is not registered in the site', ({ given, when, then }) => {
     given('An unregistered user', async () => {
-      username = "pablo"
-      password = "pabloasw"
-      await expect(page).toClick("button", { text: "Don't have an account? Register here." });
+      const timestamp = Date.now();
+      username = `user${timestamp}`;
+      password = "Test1234";
+      confirmPassword = "Test1234";
     });
 
-    when('I fill the data in the form and press submit', async () => {
-      await expect(page).toFill('input[name="username"]', username);
-      await expect(page).toFill('input[name="password"]', password);
-      await expect(page).toClick('button', { text: 'Add User' })
+    when('I fill the registration form and submit it', async () => {
+      await expect(page).toFill(`input[placeholder="${i18n.t('enter-username-placeholder')}"]`, username);
+      await expect(page).toFill(`input[placeholder="${i18n.t('enter-password-placeholder')}"]`, password);
+      await expect(page).toFill(`input[placeholder="${i18n.t('enter-confirm-password-placeholder')}"]`, confirmPassword);
+      await expect(page).toClick('button', { text: i18n.t('signup-message') });
     });
 
-    then('A confirmation message should be shown in the screen', async () => {
-        await expect(page).toMatchElement("div", { text: "User added successfully" });
+    then('A success message should appear', async () => {
+      await expect(page).toMatchElement("div.alert-success", { text: i18n.t('user-added') });
     });
-  })
+  });
 
-  afterAll(async ()=>{
-    browser.close()
-  })
+  test('The user is not registered but the password is invalid', ({ given, when, then }) => {
+    given('An unregistered user with an invalid password', async () => {
+      const timestamp = Date.now();
+      username = `invalidpass${timestamp}`;
+      password = "abc";
+      confirmPassword = "abc";
+    });
 
+    when('I fill the registration form and submit it', async () => {
+      await expect(page).toFill(`input[placeholder="${i18n.t('enter-username-placeholder')}"]`, username);
+      await expect(page).toFill(`input[placeholder="${i18n.t('enter-password-placeholder')}"]`, password);
+      await expect(page).toFill(`input[placeholder="${i18n.t('enter-confirm-password-placeholder')}"]`, confirmPassword);
+      await expect(page).toClick('button', { text: i18n.t('signup-message') });
+    });
+
+    then('An error message about password content should appear', async () => { 
+      await expect(page).toMatchElement("div.alert-danger", { text: i18n.t('password-error-content') });
+    });
+  });
+
+  test("The user is not registered, the password is valid but they don't match", ({ given, when, then }) => {
+    given('An unregistered user with valid but mismatching passwords', async () => {
+      const timestamp = Date.now();
+      username = `mismatch${timestamp}`;
+      password = "ValidPass1";
+      confirmPassword = "DifferentPass1";
+    });
+
+    when('I fill the registration form and submit it', async () => {
+      await expect(page).toFill(`input[placeholder="${i18n.t('enter-username-placeholder')}"]`, username);
+      await expect(page).toFill(`input[placeholder="${i18n.t('enter-password-placeholder')}"]`, password);
+      await expect(page).toFill(`input[placeholder="${i18n.t('enter-confirm-password-placeholder')}"]`, confirmPassword);
+      await expect(page).toClick('button', { text: i18n.t('signup-message') });
+    });
+
+    then('An error message about password mismatch should appear', async () => {
+      await expect(page).toMatchElement("div.alert-danger", { text: i18n.t('password-mismatch-error') });
+    });
+  });
+
+  afterAll(async () => {
+    await browser.close();
+  });
 });

--- a/webapp/e2e/test-environment-setup.js
+++ b/webapp/e2e/test-environment-setup.js
@@ -5,6 +5,8 @@ let userservice;
 let authservice;
 let llmservice;
 let gatewayservice;
+let questionservice;
+let gameservice;
 
 async function startServer() {
     console.log('Starting MongoDB memory server...');
@@ -15,6 +17,8 @@ async function startServer() {
     authservice = await require("../../users/authservice/auth-service");
     llmservice = await require("../../llmservice/llm-service");
     gatewayservice = await require("../../gatewayservice/gateway-service");
+    //questionservice = await require("../../questionservice/question-service");
+    //gameservice = await require("../../gameservice/game-service");
 }
 
 startServer();

--- a/webapp/public/locales/en/translation.json
+++ b/webapp/public/locales/en/translation.json
@@ -74,5 +74,6 @@
     "cancel-button": "Cancel",
     "confirm-button": "Confirm",
     "current-password": "Current Password",
-    "signup-message": "Sign Up"
+    "signup-message": "Sign Up",
+    "login-message": "Login"
 }

--- a/webapp/public/locales/en/translation.json
+++ b/webapp/public/locales/en/translation.json
@@ -66,11 +66,13 @@
     "login-failure": "Your username or password is incorrect.",
     "enter-username-placeholder": "Enter your username",
     "enter-password-placeholder": "Enter your password",
+    "enter-confirm-password-placeholder": "Confirm your password",
     "auth-error-too-many-attempts": "Too many attempts. Try again later.",
     "password-error-content": "Password must be at least 8 characters long, contain at least one uppercase letter, one number, and no spaces.",
     "confirm-logout": "Are you sure you want to log out?",
     "logout-message": "Logout",
     "cancel-button": "Cancel",
     "confirm-button": "Confirm",
-    "current-password": "Current Password"
+    "current-password": "Current Password",
+    "signup-message": "Sign Up"
 }

--- a/webapp/public/locales/es/translation.json
+++ b/webapp/public/locales/es/translation.json
@@ -66,11 +66,13 @@
     "login-success": "Se ha iniciado sesión correctamente",
     "enter-username-placeholder": "Introduzca su nombre de usuario",
     "enter-password-placeholder": "Introduzca su contraseña",
+    "enter-confirm-password-placeholder": "Confirme su contraseña",
     "auth-error-too-many-attempts": "Demasiadas intentos. Inténtelo de nuevo más tarde.",
     "password-error-content": "La contraseña debe tener al menos 8 caracteres, una letra mayúscula, un número y no contener espacios.",
     "confirm-logout": "¿Estás seguro de que deseas cerrar sesión?",
     "logout-message": "Cerrar Sesión",
     "cancel-button": "Cancelar",
     "confirm-button": "Aceptar",
-    "current-password": "Contraseña actual"
+    "current-password": "Contraseña actual",
+    "signup-message": "Sign Up"
 }

--- a/webapp/public/locales/es/translation.json
+++ b/webapp/public/locales/es/translation.json
@@ -74,5 +74,6 @@
     "cancel-button": "Cancelar",
     "confirm-button": "Aceptar",
     "current-password": "Contraseña actual",
-    "signup-message": "Sign Up"
+    "signup-message": "Sign Up",
+    "login-message": "Login"
 }

--- a/webapp/src/components/AddUser.js
+++ b/webapp/src/components/AddUser.js
@@ -115,14 +115,14 @@ export const AddUser = () => {
                   <Form.Label style={{ color: '#5D6C89', 'fontWeight': 'bold' }}>{t('password-edit-confirm')}</Form.Label>
                   <Form.Control
                     type="password"
-                    placeholder={t('enter-password-placeholder')}
+                    placeholder={t('enter-confirm-password-placeholder')}
                     value={confirmPassword}
                     onChange={(e) => setConfirmPassword(e.target.value)}
                     required
                   />
                 </Form.Group>
                 <Button type="submit" className="w-100" style={{ backgroundColor: '#FEB06A', borderColor: '#FEB06A', color: '#5D6C89' }}>
-                  Sign Up
+                    {t('signup-message')}
                 </Button>
               </Form>
               {success && <Alert variant="success" className="mt-3">{t('user-added')}</Alert>}

--- a/webapp/src/components/Login.js
+++ b/webapp/src/components/Login.js
@@ -77,7 +77,7 @@ export const Login = () => {
                   />
                 </Form.Group>
                 <Button type="submit" className="w-100" style={{ backgroundColor: '#FEB06A', borderColor: '#FEB06A', color: '#5D6C89' }}>
-                  Login
+                    {t('login-message')}
                 </Button>
               </Form>
               {loginSuccess && <Alert variant="success" className="mt-3">{t('login-success')}</Alert>}


### PR DESCRIPTION
He realizado los tests e2e para el Login y el AddUser. En ellos he contemplado:

### Login
* El usuario se logea correctamente
* El usuario se intenta logear con credenciales incorrectas.
* El usuario se intenta logear 5 veces y se bloquea el login

### AddUser
* Se añade un usuario correctamente
* El usuario no está registrado, pero la contraseña es incorrecta
* El usuario no está registrado, la contraseña es válida, pero no coincide con la confirmación de la contraseña
* El usuario se trata de registrar con un username que ya existe en el sistema

### Soporte para internacionalización (i18n) en tests e2e
He creado el archivo` i18n-test-helper.js` para facilitar la internacionalización en los tests E2E realizados con Jest y Puppeteer. Este helper permite usar las mismas claves de traducción que en la aplicación.