### PR TITLE
Mejora en las Imágenes de las Preguntas

### DIFF
--- a/webapp/src/components/game/Game.js
+++ b/webapp/src/components/game/Game.js
@@ -1,6 +1,7 @@
 import React, { useState, useEffect, useContext } from 'react';
 import { useTranslation } from 'react-i18next';
 import AnswerButton from './AnswerButton';
+import QuestionImage from './QuestionImage';
 import Timer from './Timer';
 import LLMChat from './LLMChat';
 import Modal from "react-bootstrap/Modal";
@@ -330,7 +331,7 @@ export const Game = () => {
                     <p className={question.text === "Generando Pregunta..." ? 'question-loading' : ''}>{question.text}</p>
                 </div>
                 <div className='div-question-img'>
-                    {isLoading ? <Spinner animation="border" /> : <img alt="Question" className="question-img" src={question.imageUrl} onContextMenu={(e) => e.preventDefault()} />}
+                    {isLoading ? <Spinner animation="border" /> : <QuestionImage alt="Question" className="question-img" src={question.imageUrl}  />}
                 </div>
                 <section id="question-answers-section">
                     <div id="game-answer-buttons-section">

--- a/webapp/src/components/game/QuestionImage.js
+++ b/webapp/src/components/game/QuestionImage.js
@@ -1,0 +1,32 @@
+import React, { useState } from 'react';
+
+const QuestionImage = ({ src, alt }) => {
+  const [isOpen, setIsOpen] = useState(false);
+
+  return (
+    <>
+      <img
+        src={src}
+        alt={alt}
+        className="question-img"
+        onClick={() => setIsOpen(true)}
+        onContextMenu={(e) => e.preventDefault()}
+      />
+
+      {isOpen && (
+        <div
+          className="zoomed-image-div"
+          onClick={() => setIsOpen(false)}
+        >
+          <img
+            className="zoomed-image"
+            src={src}
+            alt={alt}
+          />
+        </div>
+      )}
+    </>
+  );
+}
+
+export default QuestionImage;

--- a/webapp/src/components/game/QuestionImage.js
+++ b/webapp/src/components/game/QuestionImage.js
@@ -1,33 +1,44 @@
 import React, { useState } from 'react';
 
+/**
+ * This component displays an image that can be clicked to zoom in.
+ * 
+ * @param {String} src - The source URL of the image.
+ * @param {String} alt - The alternative text for the image.
+ * @param {String} className - Additional CSS classes to apply to the image.
+ * @returns Component that displays the image and handles zoom functionality.
+ */
 const QuestionImage = ({ src, alt, className }) => {
-  const [isOpen, setIsOpen] = useState(false);
-  const isPng = src.toLowerCase().endsWith('.png');
+    
+    // State to manage the zoomed image visibility
+    const [isOpen, setIsOpen] = useState(false);
+    // Check if the image is a PNG to apply specific styles
+    const isPng = src.toLowerCase().endsWith('.png');
 
-  return (
-    <>
-      <img
-        src={src}
-        alt={alt}
-        className={className ? className : ''}
-        onClick={() => setIsOpen(true)}
-        onContextMenu={(e) => e.preventDefault()}
-      />
+    return (
+        <>
+            <img
+                src={src}
+                alt={alt}
+                className={className ? className : ''}
+                onClick={() => setIsOpen(true)}
+                onContextMenu={(e) => e.preventDefault()}
+            />
 
-      {isOpen && (
-        <div
-          className="zoomed-image-div"
-          onClick={() => setIsOpen(false)}
-        >
-          <img
-            className={`zoomed-image ${isPng ? 'no-border' : ''}`}
-            src={src}
-            alt={alt}
-          />
-        </div>
-      )}
-    </>
-  );
+            {isOpen && (
+                <div
+                    className="zoomed-image-div"
+                    onClick={() => setIsOpen(false)}
+                >
+                    <img
+                        className={`zoomed-image ${isPng ? 'no-border' : ''}`}
+                        src={src}
+                        alt={alt}
+                    />
+                </div>
+            )}
+        </>
+    );
 }
 
 export default QuestionImage;

--- a/webapp/src/components/game/QuestionImage.js
+++ b/webapp/src/components/game/QuestionImage.js
@@ -1,14 +1,15 @@
 import React, { useState } from 'react';
 
-const QuestionImage = ({ src, alt }) => {
+const QuestionImage = ({ src, alt, className }) => {
   const [isOpen, setIsOpen] = useState(false);
+  const isPng = src.toLowerCase().endsWith('.png');
 
   return (
     <>
       <img
         src={src}
         alt={alt}
-        className="question-img"
+        className={className ? className : ''}
         onClick={() => setIsOpen(true)}
         onContextMenu={(e) => e.preventDefault()}
       />
@@ -19,7 +20,7 @@ const QuestionImage = ({ src, alt }) => {
           onClick={() => setIsOpen(false)}
         >
           <img
-            className="zoomed-image"
+            className={`zoomed-image ${isPng ? 'no-border' : ''}`}
             src={src}
             alt={alt}
           />

--- a/webapp/src/components/game/QuestionImage.js
+++ b/webapp/src/components/game/QuestionImage.js
@@ -1,7 +1,7 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 
 /**
- * This component displays an image that can be clicked to zoom in.
+ * This component displays an image that can be clicked or activated via keyboard to zoom in.
  * 
  * @param {String} src - The source URL of the image.
  * @param {String} alt - The alternative text for the image.
@@ -9,26 +9,56 @@ import React, { useState } from 'react';
  * @returns Component that displays the image and handles zoom functionality.
  */
 const QuestionImage = ({ src, alt, className }) => {
-    
-    // State to manage the zoomed image visibility
     const [isOpen, setIsOpen] = useState(false);
-    // Check if the image is a PNG to apply specific styles
     const isPng = src.toLowerCase().endsWith('.png');
+
+    const overlayRef = useRef(null);
+
+    const handleOpen = () => setIsOpen(true);
+    const handleClose = () => setIsOpen(false);
+
+    const handleImageKeyPress = (e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault();
+            handleOpen();
+        }
+    };
+
+    const handleOverlayKeyPress = (e) => {
+        if (e.key === 'Escape' || e.key === 'Enter' || e.key === ' ') {
+            handleClose();
+        }
+    };
+
+    useEffect(() => {
+        if (isOpen && overlayRef.current) {
+            overlayRef.current.focus();
+        }
+    }, [isOpen]);
 
     return (
         <>
             <img
                 src={src}
                 alt={alt}
-                className={className ? className : ''}
-                onClick={() => setIsOpen(true)}
+                className={className || ''}
+                onClick={handleOpen}
                 onContextMenu={(e) => e.preventDefault()}
+                tabIndex={0}
+                role="button"
+                onKeyDown={handleImageKeyPress}
+                aria-label="Open image zoom view"
             />
 
             {isOpen && (
                 <div
                     className="zoomed-image-div"
-                    onClick={() => setIsOpen(false)}
+                    onClick={handleClose}
+                    onKeyDown={handleOverlayKeyPress}
+                    tabIndex={0}
+                    role="button"
+                    ref={overlayRef}
+                    aria-label="Zoomed image overlay"
                 >
                     <img
                         className={`zoomed-image ${isPng ? 'no-border' : ''}`}

--- a/webapp/src/components/game/QuestionImage.test.js
+++ b/webapp/src/components/game/QuestionImage.test.js
@@ -24,6 +24,24 @@ describe('QuestionImage', () => {
     expect(zoomedImage).toHaveClass('zoomed-image');
   });
 
+  test('displays zoomed image when pressing Enter on image', () => {
+    render(<QuestionImage src={jpgSrc} alt={altText} />);
+    const image = screen.getByAltText(altText);
+    fireEvent.keyDown(image, { key: 'Enter' });
+
+    const zoomedImage = screen.getAllByAltText(altText)[1];
+    expect(zoomedImage).toBeInTheDocument();
+  });
+
+  test('displays zoomed image when pressing Space on image', () => {
+    render(<QuestionImage src={jpgSrc} alt={altText} />);
+    const image = screen.getByAltText(altText);
+    fireEvent.keyDown(image, { key: ' ' });
+
+    const zoomedImage = screen.getAllByAltText(altText)[1];
+    expect(zoomedImage).toBeInTheDocument();
+  });
+
   test('closes zoomed image when clicking on the background', () => {
     render(<QuestionImage src={jpgSrc} alt={altText} />);
     fireEvent.click(screen.getByAltText(altText));

--- a/webapp/src/components/game/QuestionImage.test.js
+++ b/webapp/src/components/game/QuestionImage.test.js
@@ -52,6 +52,22 @@ describe('QuestionImage', () => {
   
     expect(screen.queryAllByAltText(altText).length).toBe(1);
   });
+
+  test('closes zoomed image when pressing Escape', () => {
+    render(<QuestionImage src={jpgSrc} alt={altText} />);
+    fireEvent.click(screen.getByAltText(altText));
+  
+    // Ensure the zoomed image is displayed
+    expect(screen.getAllByAltText(altText).length).toBe(2);
+  
+    // Simulate Escape key press on the overlay
+    const overlay = document.querySelector('.zoomed-image-div');
+    overlay.focus(); // Necessary for key events to register
+    fireEvent.keyDown(overlay, { key: 'Escape' });
+  
+    // Expect the zoomed image to be closed
+    expect(screen.queryAllByAltText(altText).length).toBe(1);
+  });
   
 
   test('applies no-border class if image is PNG', () => {

--- a/webapp/src/components/game/QuestionImage.test.js
+++ b/webapp/src/components/game/QuestionImage.test.js
@@ -1,0 +1,54 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import QuestionImage from './QuestionImage';
+
+describe('QuestionImage', () => {
+  const altText = 'Image description';
+  const pngSrc = 'image.png';
+  const jpgSrc = 'image.jpg';
+
+  test('renders image with props', () => {
+    render(<QuestionImage src={jpgSrc} alt={altText} />);
+    const image = screen.getByAltText(altText);
+    expect(image).toBeInTheDocument();
+    expect(image).toHaveAttribute('src', jpgSrc);
+  });
+
+  test('displays zoomed image when clicked', () => {
+    render(<QuestionImage src={jpgSrc} alt={altText} />);
+    const image = screen.getByAltText(altText);
+    fireEvent.click(image);
+
+    const zoomedImage = screen.getAllByAltText(altText)[1];
+    expect(zoomedImage).toBeInTheDocument();
+    expect(zoomedImage).toHaveClass('zoomed-image');
+  });
+
+  test('closes zoomed image when clicking on the background', () => {
+    render(<QuestionImage src={jpgSrc} alt={altText} />);
+    fireEvent.click(screen.getByAltText(altText));
+  
+    // Seleccionamos el contenedor con la clase zoomed-image-div
+    const overlay = document.querySelector('.zoomed-image-div');
+    fireEvent.click(overlay);
+  
+    expect(screen.queryAllByAltText(altText).length).toBe(1);
+  });
+  
+
+  test('applies no-border class if image is PNG', () => {
+    render(<QuestionImage src={pngSrc} alt={altText} />);
+    fireEvent.click(screen.getByAltText(altText));
+
+    const zoomedImage = screen.getAllByAltText(altText)[1];
+    expect(zoomedImage).toHaveClass('no-border');
+  });
+
+  test('does not apply no-border class if image is not PNG', () => {
+    render(<QuestionImage src={jpgSrc} alt={altText} />);
+    fireEvent.click(screen.getByAltText(altText));
+
+    const zoomedImage = screen.getAllByAltText(altText)[1];
+    expect(zoomedImage).not.toHaveClass('no-border');
+  });
+});

--- a/webapp/src/components/game/game.css
+++ b/webapp/src/components/game/game.css
@@ -12,9 +12,17 @@
 /* ===================== QUESTION STYLE ===================== */
 
 @keyframes loadingAnimation {
-    0% { opacity: 1; }
-    50% { opacity: 0.5; }
-    100% { opacity: 1; }
+    0% {
+        opacity: 1;
+    }
+
+    50% {
+        opacity: 0.5;
+    }
+
+    100% {
+        opacity: 1;
+    }
 }
 
 .question-loading {
@@ -33,18 +41,22 @@
     grid-column: 1 / 4;
 }
 
-.answer-button-not-answered, .answer-button-correct-answer, .answer-button-wrong-answer {
+.answer-button-not-answered,
+.answer-button-correct-answer,
+.answer-button-wrong-answer {
     margin: 3%;
     width: 90%;
     height: 3em;
     font-size: 1.2em;
-    
+
     background-color: #5d6c89 !important;
     color: #fbf6f3 !important;
     cursor: pointer;
 }
 
-.answer-button-not-answered:disabled, .answer-button-correct-answer:disabled, .answer-button-wrong-answer:disabled {
+.answer-button-not-answered:disabled,
+.answer-button-correct-answer:disabled,
+.answer-button-wrong-answer:disabled {
     opacity: 100%;
 }
 
@@ -57,8 +69,9 @@
     color: white;
 }
 
-.answer-button-wrong-answer, .answer-button-wrong-answer:active {
-    background-color: #f71e0e !important; 
+.answer-button-wrong-answer,
+.answer-button-wrong-answer:active {
+    background-color: #f71e0e !important;
     color: white;
 }
 
@@ -78,7 +91,8 @@
 }
 
 button:not(:disabled):active {
-    transform: scale(0.98) !important; /* Slightly scale down the button to give a pressed effect */
+    transform: scale(0.98) !important;
+    /* Slightly scale down the button to give a pressed effect */
 }
 
 /* ===================== TIMER STYLE ===================== */
@@ -90,11 +104,13 @@ button:not(:disabled):active {
     grid-column: 0;
 }
 
-.game-timer, .game-timer-warning-minus-10, .game-timer-warning-minus-5 {
+.game-timer,
+.game-timer-warning-minus-10,
+.game-timer-warning-minus-5 {
     margin-left: 20%;
     font-family: 'Lucida Console', 'Monaco', monospace;
     font-size: 4vw;
-    font-weight: bolder;    
+    font-weight: bolder;
 }
 
 .game-timer {
@@ -102,7 +118,9 @@ button:not(:disabled):active {
 }
 
 @keyframes blink {
-    50% { opacity: 0; }
+    50% {
+        opacity: 0;
+    }
 }
 
 .game-timer-warning-minus-10 {
@@ -132,7 +150,7 @@ button:not(:disabled):active {
 
 .llm-chat-aside {
     margin-right: 1em;
-	padding-bottom: 10%;
+    padding-bottom: 10%;
     grid-column: -1;
     grid-row: 2/-1;
     display: flex;
@@ -151,10 +169,12 @@ button:not(:disabled):active {
     padding: 2%;
 }
 
-.llm-message, .user-message, .llm-message-loading {
+.llm-message,
+.user-message,
+.llm-message-loading {
     margin: 2% 0;
     padding: 1em;
-    border-radius: 15px; 
+    border-radius: 15px;
     word-wrap: break-word;
     font-size: 1.1vw;
 }
@@ -196,7 +216,7 @@ button:not(:disabled):active {
     background-color: rgb(237, 230, 230);
 }
 
-.send-prompt-button > img {
+.send-prompt-button>img {
     width: 70%;
     height: auto;
 }
@@ -214,14 +234,16 @@ button:not(:disabled):active {
     justify-content: space-between;
 }
 
-.llm-chat-form, .llm-chat {
+.llm-chat-form,
+.llm-chat {
     border-width: 0.2em;
 }
 
 /* ===================== POINTS STYLE ===================== */
 
 .game-points-and-exit-div {
-    position: relative; /* Add relative positioning */
+    position: relative;
+    /* Add relative positioning */
     display: flex;
     justify-content: space-between;
     align-items: center;
@@ -237,14 +259,24 @@ button:not(:disabled):active {
 }
 
 @keyframes pointsToAddAnimation {
-    0% { transform: translateY(0); opacity: 1; }
-    100% { transform: translateY(-20px); opacity: 0; } /* Adjust translateY to move less */
+    0% {
+        transform: translateY(0);
+        opacity: 1;
+    }
+
+    100% {
+        transform: translateY(-20px);
+        opacity: 0;
+    }
+
+    /* Adjust translateY to move less */
 }
 
 .points-to-add {
     position: absolute;
     right: 107%;
-    font-size: 3em; /* Make the font size even smaller */
+    font-size: 3em;
+    /* Make the font size even smaller */
     color: green;
     animation: pointsToAddAnimation 1.1s ease-in-out;
 }
@@ -256,9 +288,29 @@ button:not(:disabled):active {
     max-height: 40vh;
     height: auto;
     object-fit: contain;
+    cursor: pointer;
 }
 
+.zoomed-image-div {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background-color: rgba(0, 0, 0, 0.8);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    z-index: 1000;
+}
 
+.zoomed-image {
+    max-width: 90%;
+    max-height: 90%;
+    box-shadow: 0 0 20px white;
+  }
+  
+  
 .div-question-img {
     grid-column: 1/4;
     display: flex;
@@ -339,9 +391,11 @@ button:not(:disabled):active {
     0% {
         transform: scale(1);
     }
+
     50% {
         transform: scale(1.1);
     }
+
     100% {
         transform: scale(1);
     }
@@ -349,7 +403,7 @@ button:not(:disabled):active {
 
 .game-results-button {
     margin: 4% 0%;
-    background-color:#475a80;
+    background-color: #475a80;
     font-size: 1vw !important;
 }
 
@@ -374,21 +428,36 @@ button:not(:disabled):active {
 }
 
 @keyframes shake {
-    0% { transform: translateX(0); }
-    25% { transform: translateX(-5px); }
-    50% { transform: translateX(5px); }
-    75% { transform: translateX(-5px); }
-    100% { transform: translateX(0); }
-  }
-  
-  .answer-button-wrong-answer {
+    0% {
+        transform: translateX(0);
+    }
+
+    25% {
+        transform: translateX(-5px);
+    }
+
+    50% {
+        transform: translateX(5px);
+    }
+
+    75% {
+        transform: translateX(-5px);
+    }
+
+    100% {
+        transform: translateX(0);
+    }
+}
+
+.answer-button-wrong-answer {
     animation: shake 0.4s ease;
-  }
+}
 
 .chaos-mode .points-to-remove {
     position: absolute;
     right: 107%;
-    font-size: 3em; /* Make the font size even smaller */
+    font-size: 3em;
+    /* Make the font size even smaller */
     color: rgb(217, 38, 14);
     animation: pointsToAddAnimation 1.1s ease-in-out;
 }
@@ -401,24 +470,25 @@ button:not(:disabled):active {
     height: 100%;
     object-fit: cover;
     z-index: -1;
-    pointer-events: none; /* El video no bloquea clics */
-  }
+    pointer-events: none;
+    /* El video no bloquea clics */
+}
 
 .chaos-mode .game-questions-answered {
     color: white;
-  }
+}
 
 .chaos-mode .game-points-and-exit-div {
     color: white;
-  }
+}
 
 .chaos-mode .game-question {
     color: white;
-  }
+}
 
 .chaos-mode .game-timer {
     color: red;
-  }
+}
 
 .chaos-mode .llm-icon {
     width: 170%;

--- a/webapp/src/components/game/game.css
+++ b/webapp/src/components/game/game.css
@@ -301,7 +301,7 @@ button:not(:disabled):active {
     display: flex;
     justify-content: center;
     align-items: center;
-    z-index: 1000;
+    z-index: 9999;
 }
 
 .zoomed-image {
@@ -310,12 +310,22 @@ button:not(:disabled):active {
     box-shadow: 0 0 20px white;
   }
   
+.no-border {
+    box-shadow: none;
+}
   
 .div-question-img {
     grid-column: 1/4;
     display: flex;
     justify-content: center;
     align-items: center;
+}
+
+.history-img {
+    width: 100%;
+    height: auto;
+    max-width: 200px;
+    cursor: pointer;
 }
 
 /* ===================== QUESTION STYLE ===================== */

--- a/webapp/src/components/gameHistory/QuestionAccordion.js
+++ b/webapp/src/components/gameHistory/QuestionAccordion.js
@@ -2,6 +2,8 @@ import React from 'react';
 import 'bootstrap/dist/css/bootstrap.min.css';
 import Accordion from 'react-bootstrap/Accordion';
 import Image from 'react-bootstrap/Image';
+import QuestionImage from '../game/QuestionImage';
+import '../game/game.css';
 
 /** 
  * This component represents each of the questions displayed in the history or summary of a game.
@@ -17,11 +19,11 @@ export const QuestionAccordion = ({ questions }) => {
                     <Accordion.Item eventKey={index.toString()} key={index}>
                         <Accordion.Header>{index + 1}. {question.text}</Accordion.Header>
                         <Accordion.Body>
-                            <Image
+                            <QuestionImage
                                 src={question.imageUrl}
+                                alt={question.text}
                                 rounded
-                                className="img-fluid"
-                                style={{ maxWidth: '200px', height: 'auto' }}
+                                className="history-img"
                             />
                             {question.answers.map((answer, i) => {
                                 let symbol = '';


### PR DESCRIPTION
## Nuevo Componente QuestionImage

He implementado un nuevo componente QuestionImage que permite que, al hacer click sobre la imagen, muestre la imagen con zoom en primer plano, de forma que sea mucho más fácil de visualizar.

Este componente se ha usado al mostrar la imagen durante una partida y también al mostrar imágenes de las preguntas en el historial

## Tests del Componente

He implementado tests unitarios del componente a fin de que no baje el code coverage por su implementación

## Resultado Final

Al hacer click en la imagen, esta se muestra en primer plano y con zoom de la siguiente manera:

### Sin zoom

<img width="1512" alt="image" src="https://github.com/user-attachments/assets/b9574126-5649-4c03-8953-7bf1e909b721" />

### Con zoom

<img width="1512" alt="image" src="https://github.com/user-attachments/assets/aec17adc-bd13-44b8-90b2-d643c0a13ba4" />
